### PR TITLE
Modify the position of `-lm` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 #                           Macros
 #                           -------------------------------------
 LL_PATH =                   ../ll/
-C  =                        gcc -lm -I$(LL_PATH)include -Iinclude -I../include -o dsp
+C  =                        gcc -I$(LL_PATH)include -Iinclude -I../include -o dsp
 LL =                        $(LL_PATH)src/core/common/*.c $(LL_PATH)src/core/posix/*.c
 
 #                           -------------------------------------
@@ -22,10 +22,10 @@ LL =                        $(LL_PATH)src/core/common/*.c $(LL_PATH)src/core/pos
 .PHONY: all debug clean pack
 
 all:
-	                        cd bin; $(C) -O4 $(LL) ../src/*.c
+	                        cd bin; $(C) -O4 $(LL) ../src/*.c -lm
 
 debug:
-	                        cd bin; $(C) -O0 -g -fbuiltin -Wall -Wextra $(LL) ../src/*.c
+	                        cd bin; $(C) -O0 -g -fbuiltin -Wall -Wextra $(LL) ../src/*.c -lm
 
 clean:
 	                        cd bin; rm -f *


### PR DESCRIPTION
The original position of `-lm` did not work on my machine, and putting it to a later position works for me.